### PR TITLE
Address warning.

### DIFF
--- a/src/uStepperS.h
+++ b/src/uStepperS.h
@@ -466,7 +466,7 @@ public:
 	 *
 	 * @return     The angle moved.
 	 */
-	bool uStepperS::getMotorState(uint8_t statusType = POSITION_REACHED);
+	bool getMotorState(uint8_t statusType = POSITION_REACHED);
 
 	/**
 	 * @brief      Stop the motor


### PR DESCRIPTION
.../uStepperS.h:469:7: warning: extra qualification 'uStepperS::' on member 'getMotorState' [-fpermissive]