### PR TITLE
Fix setHome use of parameter in uStepperS setup()

### DIFF
--- a/src/uStepperS.cpp
+++ b/src/uStepperS.cpp
@@ -124,7 +124,7 @@ void uStepperS::setup(	uint8_t mode,
 	this->setCurrent(40.0);
 	this->setHoldCurrent(25.0);	
 
-	encoder.setHome();
+  unsigned int tempInitialEncoderAngle = this->encoder.getAngle();
 
 	if(this->mode)
 	{
@@ -187,7 +187,7 @@ void uStepperS::setup(	uint8_t mode,
 
 	while(this->getMotorState());
 
-	if(this->encoder.getAngleMoved() < -5)
+	if(tempInitialEncoderAngle - this->encoder.getAngle() < -5)
 	{
 		this->driver.setShaftDirection(1);
 	}
@@ -196,8 +196,11 @@ void uStepperS::setup(	uint8_t mode,
 		this->driver.setShaftDirection(0);
 	}
 	
-	encoder.setHome();
-
+	if(setHome)
+  {
+    encoder.setHome();
+  }
+  
 	this->pidDisabled = 0;
 
 	DDRB |= (1 << 4);


### PR DESCRIPTION
Will now only reset encoder angle read to zero on setup() if setHome param is set to true. (See issue #14 .) Allowing reading angle as from an absolute encoder (maintaining position between resets and power cycles).

This is a quick start, it appears to work for uStepper S' setup in NORMAL mode.

It seems that PID mode requires something a little more in depth...

I haven't had a chance to test DROPIN mode.

